### PR TITLE
TestCasAuthService moving suggestion to the Pest configuration

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -14,15 +14,7 @@ class AppServiceProvider extends ServiceProvider
      */
     public function register(): void
     {
-        $this->app->bind(CasAuthInterface::class, function ($app) {
-            // Check if we are running tests
-            if ($app->runningUnitTests()) {
-                return new TestCasAuthService();
-            } else {
-                // In production, use the production authentication service
-                return new ProductionCasAuthService();
-            }
-        });
+        $this->app->bind(CasAuthInterface::class, ProductionCasAuthService::class);
     }
 
     /**

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Contracts\CasAuthInterface;
+use App\Services\TestCasAuthService;
 use App\Models\CasUser;
 use App\Models\Role;
 use Illuminate\Foundation\Testing\LazilyRefreshDatabase;

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -17,7 +17,11 @@ use Tests\TestCase;
 |
 */
 
-uses(TestCase::class, LazilyRefreshDatabase::class)->in('Feature');
+uses(TestCase::class, LazilyRefreshDatabase::class)
+    ->beforeEach(function () {
+        $this->app->bind(CasAuthInterface::class, TestCasAuthService::class);
+    })
+    ->in('Feature');
 
 /*
 |--------------------------------------------------------------------------


### PR DESCRIPTION
Hi,
I have encountered a similar problem with tests with VILT stack and subfission/cas package.

I found your posts at the pestphp/pest#1046 and subfission/cas#124. Much appreciate your contribution to the discussion of this problem. Be sure, your contribution is very valuable 👍👍 And thanks for publishing a link to this repo, so other can use your solution as an example to resolve this problem in their projects.

Also, I've found an [information about interface binding at the AppServiceProvider.php](https://laracasts.com/discuss/channels/code-review/laravel-58-interface-binding-while-running-tests) (Sti3bas answer) and I fully agree with his opinion: tests related code is not a good idea. So I came back to you with a code suggestion how it can be improved.

- At the `AuthServiceProvider` interface binding can always stay in a production "state"
- Instead of depending on state of application and binding different container at the runtime, the test service could be binded only for tests purposes in a Pest configuration.

As a result, an `if()` directive will be eliminated from `AuthServiceProvider` and will no longer called during any of request.

Hope this PR can help you to improve your codebase 😃